### PR TITLE
don't build universal wheels on x86-mac.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     - uses: messense/maturin-action@v1
       with:
         command: build
-        args: --release -o dist --target universal2-apple-darwin
+        args: --release -o dist
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,17 +103,26 @@ jobs:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'  # Specify the Python version explicitly
     - uses: messense/maturin-action@v1
       with:
         command: build
         args: --release -o dist
+    - name: List dist directory
+      run: ls -l dist
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:
         name: wheels
         path: dist
     - run: pip install -U pytest
-    - run: pip install --no-index --find-links ./dist evtx
+    - name: Install evtx
+      run: |
+        pip install --no-index --find-links ./dist evtx
+        pip list  # List installed packages
     - run: pytest
 
   macos-aarch64:


### PR DESCRIPTION
since we have separate runners for aarch64 and x86 macs, we can drop building the universal wheels, and stick to building separate optimized wheels for apple silicon